### PR TITLE
允许通过DbField给特定field绑定convertor

### DIFF
--- a/bean-searcher/pom.xml
+++ b/bean-searcher/pom.xml
@@ -20,6 +20,12 @@
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.36</version>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.13.3</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/Convertor.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/Convertor.java
@@ -1,7 +1,7 @@
 package com.ejlchina.searcher;
 
 /**
- * @author Troy.Zhou @ 2022-07-07
+ * @author Minglei.tu @ 2022-07-07
  *
  * 数据库字段值转换接口
  * 用于把 数据库查出的字段值 型转为 另外一种值

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/Convertor.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/Convertor.java
@@ -1,0 +1,25 @@
+package com.ejlchina.searcher;
+
+/**
+ * @author Troy.Zhou @ 2022-07-07
+ *
+ * 数据库字段值转换接口
+ * 用于把 数据库查出的字段值 型转为 另外一种值
+ *
+ * 由于该接口缺少 {@link FieldConvertor} 引入的 {@link FieldConvertor#supports} 检测方法，
+ * 为防止误判常通过 {@link com.ejlchina.searcher.bean.DbField#converter} 绑定使用
+ *
+ * @since v3.8.1
+ */
+public interface Convertor {
+
+    /**
+     * 把 value 转换为 targetType 类型的数据
+     * v3.2.0 后移除冗余参数 targetType，该参数可通过 meta.getType() 获取
+     * @param meta 需要转换的字段元信息（非空）
+     * @param value 从数据库取出的待转换的值（非空）
+     * @return 转换目标值
+     * */
+    Object convert(FieldMeta meta, Object value);
+
+}

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/DbMapping.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/DbMapping.java
@@ -171,16 +171,23 @@ public interface DbMapping {
          */
         private final DbType dbType;
 
+        /**
+         * 绑定于该字段的FieldConvertor
+         * @since v3.8.1
+         */
+        private final Class<? extends FieldConvertor> convClazz;
+
         public Column(String fieldSql, boolean conditional, Class<? extends FieldOp>[] onlyOn, DbType dbType) {
-            this(fieldSql, conditional, onlyOn, null, dbType);
+            this(fieldSql, conditional, onlyOn, null, dbType, null);
         }
 
-        public Column(String fieldSql, boolean conditional, Class<? extends FieldOp>[] onlyOn, String alias, DbType dbType) {
+        public Column(String fieldSql, boolean conditional, Class<? extends FieldOp>[] onlyOn, String alias, DbType dbType, Class<? extends FieldConvertor> convClazz) {
             this.fieldSql = fieldSql;
             this.conditional = conditional;
             this.onlyOn = onlyOn;
             this.alias = alias;
             this.dbType = dbType;
+            this.convClazz = convClazz;
         }
 
         public String getFieldSql() {
@@ -201,6 +208,10 @@ public interface DbMapping {
 
         public DbType getDbType() {
             return dbType;
+        }
+
+        public Class<? extends FieldConvertor> getConvClazz() {
+            return convClazz;
         }
 
     }

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/DbMapping.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/DbMapping.java
@@ -175,13 +175,13 @@ public interface DbMapping {
          * 绑定于该字段的FieldConvertor
          * @since v3.8.1
          */
-        private final Class<? extends FieldConvertor> convClazz;
+        private final Class<? extends Convertor> convClazz;
 
         public Column(String fieldSql, boolean conditional, Class<? extends FieldOp>[] onlyOn, DbType dbType) {
             this(fieldSql, conditional, onlyOn, null, dbType, null);
         }
 
-        public Column(String fieldSql, boolean conditional, Class<? extends FieldOp>[] onlyOn, String alias, DbType dbType, Class<? extends FieldConvertor> convClazz) {
+        public Column(String fieldSql, boolean conditional, Class<? extends FieldOp>[] onlyOn, String alias, DbType dbType, Class<? extends Convertor> convClazz) {
             this.fieldSql = fieldSql;
             this.conditional = conditional;
             this.onlyOn = onlyOn;
@@ -210,7 +210,7 @@ public interface DbMapping {
             return dbType;
         }
 
-        public Class<? extends FieldConvertor> getConvClazz() {
+        public Class<? extends Convertor> getConvClazz() {
             return convClazz;
         }
 

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/FieldConvertor.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/FieldConvertor.java
@@ -11,7 +11,7 @@ import com.ejlchina.searcher.implement.DefaultMapSearcher;
  * 为提高字段转换效能，v3.1.0 把字段转换器拆为两类：{@link BFieldConvertor } 与 {@link MFieldConvertor }
  * 以降低 {@link #supports(FieldMeta, Class)} 方法判断次数
  */
-public interface FieldConvertor {
+public interface FieldConvertor extends Convertor {
 
 	/**
 	 * @since v3.0.0

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/FieldMeta.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/FieldMeta.java
@@ -46,13 +46,13 @@ public class FieldMeta {
     private final DbType dbType;
 
     /**
-     * 专门为该字段绑定的 FieldConvertor，为空则会从公用 convertors 匹配查找
+     * 专门为该字段绑定的 Convertor，为空则会从公用 convertors 匹配查找
      * @since v3.8.1
      */
-    private final Class<? extends Convertor> convClazz;
+    private final Convertor convertor;
 
     public FieldMeta(BeanMeta<?> beanMeta, Field field, SqlSnippet fieldSql, String dbAlias, boolean conditional,
-                     Class<? extends FieldOp>[] onlyOn, DbType dbType, Class<? extends Convertor> convClazz) {
+                     Class<? extends FieldOp>[] onlyOn, DbType dbType, Convertor convertor) {
         this.beanMeta = beanMeta;
         this.field = field;
         this.fieldSql = fieldSql;
@@ -60,7 +60,7 @@ public class FieldMeta {
         this.conditional = conditional;
         this.onlyOn = onlyOn;
         this.dbType = dbType;
-        this.convClazz = convClazz;
+        this.convertor = convertor;
     }
 
     public BeanMeta<?> getBeanMeta() {
@@ -99,8 +99,8 @@ public class FieldMeta {
         return dbType;
     }
 
-    public Class<? extends Convertor> getConvClazz() {
-        return convClazz;
+    public Convertor getConvertor() {
+        return convertor;
     }
 
 }

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/FieldMeta.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/FieldMeta.java
@@ -45,8 +45,14 @@ public class FieldMeta {
      */
     private final DbType dbType;
 
+    /**
+     * 专门为该字段绑定的 FieldConvertor，为空则会从公用 convertors 匹配查找
+     * @since v3.8.1
+     */
+    private final Class<? extends FieldConvertor> convClazz;
+
     public FieldMeta(BeanMeta<?> beanMeta, Field field, SqlSnippet fieldSql, String dbAlias, boolean conditional,
-                     Class<? extends FieldOp>[] onlyOn, DbType dbType) {
+                     Class<? extends FieldOp>[] onlyOn, DbType dbType, Class<? extends FieldConvertor> convClazz) {
         this.beanMeta = beanMeta;
         this.field = field;
         this.fieldSql = fieldSql;
@@ -54,6 +60,7 @@ public class FieldMeta {
         this.conditional = conditional;
         this.onlyOn = onlyOn;
         this.dbType = dbType;
+        this.convClazz = convClazz;
     }
 
     public BeanMeta<?> getBeanMeta() {
@@ -90,6 +97,10 @@ public class FieldMeta {
 
     public DbType getDbType() {
         return dbType;
+    }
+
+    public Class<? extends FieldConvertor> getConvClazz() {
+        return convClazz;
     }
 
 }

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/FieldMeta.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/FieldMeta.java
@@ -49,10 +49,10 @@ public class FieldMeta {
      * 专门为该字段绑定的 FieldConvertor，为空则会从公用 convertors 匹配查找
      * @since v3.8.1
      */
-    private final Class<? extends FieldConvertor> convClazz;
+    private final Class<? extends Convertor> convClazz;
 
     public FieldMeta(BeanMeta<?> beanMeta, Field field, SqlSnippet fieldSql, String dbAlias, boolean conditional,
-                     Class<? extends FieldOp>[] onlyOn, DbType dbType, Class<? extends FieldConvertor> convClazz) {
+                     Class<? extends FieldOp>[] onlyOn, DbType dbType, Class<? extends Convertor> convClazz) {
         this.beanMeta = beanMeta;
         this.field = field;
         this.fieldSql = fieldSql;
@@ -99,7 +99,7 @@ public class FieldMeta {
         return dbType;
     }
 
-    public Class<? extends FieldConvertor> getConvClazz() {
+    public Class<? extends Convertor> getConvClazz() {
         return convClazz;
     }
 

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/bean/DbField.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/bean/DbField.java
@@ -1,7 +1,7 @@
 package com.ejlchina.searcher.bean;
 
+import com.ejlchina.searcher.Convertor;
 import com.ejlchina.searcher.DbMapping;
-import com.ejlchina.searcher.FieldConvertor;
 import com.ejlchina.searcher.FieldOp;
 
 import java.lang.annotation.*;
@@ -55,10 +55,10 @@ public @interface DbField {
 	DbType type() default DbType.UNKNOWN;
 
 	/**
-	 * 绑定FieldConvertor，该Convertor只用于确定场景下的数值转换，不会与其他Convertor冲突
+	 * 绑定Convertor，针对确定的场景（指定的表/字段->当前类/field）做数值转换
 	 * @since v3.8.1
-	 * @return Class<? extends FieldConvertor>
+	 * @return Class<? extends Convertor>
 	 */
-	Class<? extends FieldConvertor> converter() default FieldConvertor.class;
+	Class<? extends Convertor> converter() default Convertor.class;
 
 }

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/bean/DbField.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/bean/DbField.java
@@ -1,6 +1,7 @@
 package com.ejlchina.searcher.bean;
 
 import com.ejlchina.searcher.DbMapping;
+import com.ejlchina.searcher.FieldConvertor;
 import com.ejlchina.searcher.FieldOp;
 
 import java.lang.annotation.*;
@@ -52,5 +53,12 @@ public @interface DbField {
 	 * @return DbType
 	 */
 	DbType type() default DbType.UNKNOWN;
+
+	/**
+	 * 绑定FieldConvertor，该Convertor只用于确定场景下的数值转换，不会与其他Convertor冲突
+	 * @since v3.8.1
+	 * @return Class<? extends FieldConvertor>
+	 */
+	Class<? extends FieldConvertor> converter() default FieldConvertor.class;
 
 }

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/implement/DefaultBeanReflector.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/implement/DefaultBeanReflector.java
@@ -15,7 +15,7 @@ import java.util.function.Function;
 public class DefaultBeanReflector implements BeanReflector {
 
 	private List<BFieldConvertor> convertors;
-	private Map<Class<?>, FieldConvertor> onCallConvertors;
+	private Map<Class<?>, Convertor> onCallConvertors;
 
 	public DefaultBeanReflector() {
 		this(new ArrayList<>());
@@ -61,7 +61,7 @@ public class DefaultBeanReflector implements BeanReflector {
 			return value;
 		}
 		if (meta.getConvClazz() != null) {
-			FieldConvertor convertor = getFieldConvertor(meta.getConvClazz());
+			Convertor convertor = getOnCallConvertor(meta.getConvClazz());
 			return convertor.convert(meta, value);
 		}
 		for (FieldConvertor convertor: convertors) {
@@ -84,9 +84,9 @@ public class DefaultBeanReflector implements BeanReflector {
 		}
 	}
 
-	protected FieldConvertor getFieldConvertor(Class<? extends FieldConvertor> convClazz) {
+	protected Convertor getOnCallConvertor(Class<? extends Convertor> convClazz) {
 		if (!onCallConvertors.containsKey(convClazz)) {
-			FieldConvertor convertor = newInstance(convClazz);
+			Convertor convertor = newInstance(convClazz);
 			onCallConvertors.put(convClazz, convertor);
 		}
 		return onCallConvertors.get(convClazz);
@@ -106,11 +106,11 @@ public class DefaultBeanReflector implements BeanReflector {
 		}
 	}
 
-	public Map<Class<?>, FieldConvertor> getOnCallConvertors() {
+	public Map<Class<?>, Convertor> getOnCallConvertors() {
 		return onCallConvertors;
 	}
 
-	public void setOnCallConvertors(Map<Class<?>, FieldConvertor> convertors) {
+	public void setOnCallConvertors(Map<Class<?>, Convertor> convertors) {
 		this.onCallConvertors = Objects.requireNonNull(convertors);
 	}
 

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/implement/DefaultBeanReflector.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/implement/DefaultBeanReflector.java
@@ -60,9 +60,8 @@ public class DefaultBeanReflector implements BeanReflector {
 			// 如果 targetType 是 valueType 的父类，则直接返回
 			return value;
 		}
-		if (meta.getConvClazz() != null) {
-			Convertor convertor = getOnCallConvertor(meta.getConvClazz());
-			return convertor.convert(meta, value);
+		if (meta.getConvertor() != null) {
+			return meta.getConvertor().convert(meta, value);
 		}
 		for (FieldConvertor convertor: convertors) {
 			if (convertor.supports(meta, valueType)) {
@@ -84,14 +83,6 @@ public class DefaultBeanReflector implements BeanReflector {
 		}
 	}
 
-	protected Convertor getOnCallConvertor(Class<? extends Convertor> convClazz) {
-		if (!onCallConvertors.containsKey(convClazz)) {
-			Convertor convertor = newInstance(convClazz);
-			onCallConvertors.put(convClazz, convertor);
-		}
-		return onCallConvertors.get(convClazz);
-	}
-
 	public List<BFieldConvertor> getConvertors() {
 		return convertors;
 	}
@@ -103,20 +94,6 @@ public class DefaultBeanReflector implements BeanReflector {
 	public void addConvertor(BFieldConvertor convertor) {
 		if (convertor != null) {
 			convertors.add(convertor);
-		}
-	}
-
-	public Map<Class<?>, Convertor> getOnCallConvertors() {
-		return onCallConvertors;
-	}
-
-	public void setOnCallConvertors(Map<Class<?>, Convertor> convertors) {
-		this.onCallConvertors = Objects.requireNonNull(convertors);
-	}
-
-	public void addOnCallConvertor(BFieldConvertor convertor) {
-		if (convertor != null) {
-			onCallConvertors.put(convertor.getClass(), convertor);
 		}
 	}
 

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/implement/DefaultDbMapping.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/implement/DefaultDbMapping.java
@@ -1,9 +1,6 @@
 package com.ejlchina.searcher.implement;
 
-import com.ejlchina.searcher.DbMapping;
-import com.ejlchina.searcher.FieldConvertor;
-import com.ejlchina.searcher.FieldOp;
-import com.ejlchina.searcher.SearchException;
+import com.ejlchina.searcher.*;
 import com.ejlchina.searcher.bean.*;
 import com.ejlchina.searcher.util.StringUtils;
 import org.slf4j.Logger;
@@ -110,7 +107,7 @@ public class DefaultDbMapping implements DbMapping {
             if (dbType == DbType.UNKNOWN) {
                 dbType = dbTypeMapper.map(field.getType());
             }
-            Class<? extends FieldConvertor> convClazz = dbField.converter() != FieldConvertor.class ? dbField.converter() : null;
+            Class<? extends Convertor> convClazz = dbField.converter() != Convertor.class ? dbField.converter() : null;
             return new Column(fieldSql, dbField.conditional(), dbField.onlyOn(), dbField.alias(), dbType, convClazz);
         }
         DbType dbType = dbTypeMapper.map(field.getType());

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/implement/DefaultDbMapping.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/implement/DefaultDbMapping.java
@@ -1,6 +1,7 @@
 package com.ejlchina.searcher.implement;
 
 import com.ejlchina.searcher.DbMapping;
+import com.ejlchina.searcher.FieldConvertor;
 import com.ejlchina.searcher.FieldOp;
 import com.ejlchina.searcher.SearchException;
 import com.ejlchina.searcher.bean.*;
@@ -109,7 +110,8 @@ public class DefaultDbMapping implements DbMapping {
             if (dbType == DbType.UNKNOWN) {
                 dbType = dbTypeMapper.map(field.getType());
             }
-            return new Column(fieldSql, dbField.conditional(), dbField.onlyOn(), dbField.alias(), dbType);
+            Class<? extends FieldConvertor> convClazz = dbField.converter() != FieldConvertor.class ? dbField.converter() : null;
+            return new Column(fieldSql, dbField.conditional(), dbField.onlyOn(), dbField.alias(), dbType, convClazz);
         }
         DbType dbType = dbTypeMapper.map(field.getType());
         return new Column(fieldSql, true, EMPTY_OPERATORS, dbType);

--- a/bean-searcher/src/main/java/com/ejlchina/searcher/implement/DefaultMetaResolver.java
+++ b/bean-searcher/src/main/java/com/ejlchina/searcher/implement/DefaultMetaResolver.java
@@ -97,7 +97,8 @@ public class DefaultMetaResolver implements MetaResolver {
                     beanMeta, wrapper.field, fieldSql, fieldAlias,
                     wrapper.column.isConditional(),
                     wrapper.column.getOnlyOn(),
-                    wrapper.column.getDbType()
+                    wrapper.column.getDbType(),
+                    wrapper.column.getConvClazz()
             );
             beanMeta.addFieldMeta(wrapper.field.getName(), fieldMeta);
         }

--- a/bean-searcher/src/test/java/com/ejlchina/searcher/BeanRefactorTestCase.java
+++ b/bean-searcher/src/test/java/com/ejlchina/searcher/BeanRefactorTestCase.java
@@ -25,7 +25,7 @@ public class BeanRefactorTestCase {
         private String name;
         @DbField(alias = "age")
         private int age;
-        @DbField(alias = "attrs", conditional = false, converter = Json2MapConverter.class)
+        @DbField(alias = "attrs", conditional = false, converter = Json2MapConvertor.class)
         private Map<String,String> attrs;
         @DbField(alias = "dateCreated")
         private Date dateCreated;
@@ -50,7 +50,7 @@ public class BeanRefactorTestCase {
         private void assertEquals(Object expect, Object value) throws Exception {
             if (expect instanceof String) {
                 if (value instanceof Map) {
-                    Assert.assertEquals(expect, Json2MapConverter.OBJECT_MAPPER.writeValueAsString(value));
+                    Assert.assertEquals(expect, Json2MapConvertor.OBJECT_MAPPER.writeValueAsString(value));
                 } else {
                     Assert.assertEquals(expect, String.valueOf(value));
                 }
@@ -109,7 +109,7 @@ public class BeanRefactorTestCase {
         values2.put("id", "100");
         values2.put("name", "Tom");
         values2.put("age", 20L);
-        values2.put("attrs", Json2MapConverter.OBJECT_MAPPER.writeValueAsString(attrs));
+        values2.put("attrs", Json2MapConvertor.OBJECT_MAPPER.writeValueAsString(attrs));
         values2.put("dateCreated", LocalDateTime.now());
 
         beanReflector.reflect(beanMeta, fieldSet, values2::get).assertEqual(values2);
@@ -118,16 +118,11 @@ public class BeanRefactorTestCase {
 
     //--
 
-    public static class Json2MapConverter implements FieldConvertor.BFieldConvertor {
+    public static class Json2MapConvertor implements Convertor {
         private static final TypeReference<Map<String,String>> MAP_STRING_TYPE = new TypeReference<Map<String,String>>() {};
         private static final TypeReference<Map<String,Object>> MAP_OBJECT_TYPE = new TypeReference<Map<String,Object>>() {};
 
         private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-        @Override
-        public boolean supports(FieldMeta meta, Class<?> valueType) {
-            throw new UnsupportedOperationException(""); //无需实现
-        }
 
         @Override
         public Object convert(FieldMeta meta, Object value) {

--- a/bean-searcher/src/test/java/com/ejlchina/searcher/BeanRefactorTestCase.java
+++ b/bean-searcher/src/test/java/com/ejlchina/searcher/BeanRefactorTestCase.java
@@ -4,9 +4,14 @@ import com.ejlchina.searcher.bean.DbField;
 import com.ejlchina.searcher.convertor.*;
 import com.ejlchina.searcher.implement.DefaultBeanReflector;
 import com.ejlchina.searcher.implement.DefaultMetaResolver;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -20,6 +25,8 @@ public class BeanRefactorTestCase {
         private String name;
         @DbField(alias = "age")
         private int age;
+        @DbField(alias = "attrs", conditional = false, converter = Json2MapConverter.class)
+        private Map<String,String> attrs;
         @DbField(alias = "dateCreated")
         private Date dateCreated;
 
@@ -28,19 +35,25 @@ public class BeanRefactorTestCase {
             return "id=" + id +
                     ", name='" + name + '\'' +
                     ", age=" + age +
+                    ", attrs=" + attrs +
                     ", dateCreated=" + format.format(dateCreated);
         }
 
-        public void assertEqual(Map<String, Object> values) {
+        public void assertEqual(Map<String, Object> values) throws Exception {
             assertEquals(values.get("id"), id);
             assertEquals(values.get("name"), name);
             assertEquals(values.get("age"), age);
+            assertEquals(values.get("attrs"), attrs);
             assertEquals(values.get("dateCreated"), dateCreated);
         }
 
-        private void assertEquals(Object expect, Object value) {
+        private void assertEquals(Object expect, Object value) throws Exception {
             if (expect instanceof String) {
-                Assert.assertEquals(expect, String.valueOf(value));
+                if (value instanceof Map) {
+                    Assert.assertEquals(expect, Json2MapConverter.OBJECT_MAPPER.writeValueAsString(value));
+                } else {
+                    Assert.assertEquals(expect, String.valueOf(value));
+                }
             } else if (expect instanceof Number && value instanceof Number) {
                 Assert.assertEquals(((Number) expect).longValue(), ((Number) value).longValue());
             } else if (value instanceof Date) {
@@ -76,7 +89,7 @@ public class BeanRefactorTestCase {
     ));
 
     @Test
-    public void test() {
+    public void test() throws Exception {
         BeanMeta<TestBean> beanMeta = metaResolver.resolve(TestBean.class);
         Collection<FieldMeta> fieldSet = beanMeta.getFieldMetas();
 
@@ -88,15 +101,46 @@ public class BeanRefactorTestCase {
 
         beanReflector.reflect(beanMeta, fieldSet, values1::get).assertEqual(values1);
 
+        Map<String,String> attrs = new HashMap<>();
+        attrs.put("tel", "1234567890");
+        attrs.put("address", "中国江西");
+
         Map<String, Object> values2 = new HashMap<>();
         values2.put("id", "100");
         values2.put("name", "Tom");
         values2.put("age", 20L);
+        values2.put("attrs", Json2MapConverter.OBJECT_MAPPER.writeValueAsString(attrs));
         values2.put("dateCreated", LocalDateTime.now());
 
         beanReflector.reflect(beanMeta, fieldSet, values2::get).assertEqual(values2);
         System.out.println("BeanRefactorTests OK!");
     }
 
+    //--
+
+    public static class Json2MapConverter implements FieldConvertor.BFieldConvertor {
+        private static final TypeReference<Map<String,String>> MAP_STRING_TYPE = new TypeReference<Map<String,String>>() {};
+        private static final TypeReference<Map<String,Object>> MAP_OBJECT_TYPE = new TypeReference<Map<String,Object>>() {};
+
+        private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+        @Override
+        public boolean supports(FieldMeta meta, Class<?> valueType) {
+            throw new UnsupportedOperationException(""); //无需实现
+        }
+
+        @Override
+        public Object convert(FieldMeta meta, Object value) {
+            Type[] typeParas = ((ParameterizedType) meta.getField().getGenericType()).getActualTypeArguments();
+            try {
+                return typeParas[1] == String.class
+                        ? OBJECT_MAPPER.readValue((String) value, MAP_STRING_TYPE)
+                        : OBJECT_MAPPER.readValue((String) value, MAP_OBJECT_TYPE)
+                        ;
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
 
 }


### PR DESCRIPTION
在复杂些的使用场景中，可能会存在相同的DbType绑定到不同的JavaType的情况，比如
- (db) json array 绑定到 (java) List<String>
- (db) json object 绑定到 (java) Map<String,String>

这种情况下很难使用公共配置的convertor，需要bean-searcher能支持针对不同的bean/field指定不同的convertor。

这个PR就是增加这种支持。

(注：我这边编码风格/方式未必贴合bean-searcher要求，如有不妥之处请批评指正)
